### PR TITLE
docs: add Global Dev Docs Standard link and cross-repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,19 @@ Da sich lokale Entwicklung und Cloud-Hosting grundlegend unterscheiden, ist die 
 Wenn du Tools hinzufügen oder Config-Anpassungen vorschlagen möchtest, öffne gerne einen Pull Request oder erstelle ein Issue.
 
 Lies vorher die [Contributing Guidelines](https://github.com/OpenSIN-AI/.github/blob/main/CONTRIBUTING.md) und den [GitHub Collaboration Guide](./github/github-collaboration-readme.md).
+
+## 📚 Documentation
+
+This repository follows the [Global Dev Docs Standard](https://github.com/OpenSIN-AI/Global-Dev-Docs-Standard).
+
+For contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
+For security policy, see [SECURITY.md](SECURITY.md).
+For the complete OpenSIN ecosystem, see [OpenSIN-AI Organization](https://github.com/OpenSIN-AI).
+
+## 🔗 See Also
+
+- [OpenSIN Core](https://github.com/OpenSIN-AI/OpenSIN) — Main platform
+- [OpenSIN-Code](https://github.com/OpenSIN-AI/OpenSIN-Code) — CLI
+- [OpenSIN-backend](https://github.com/OpenSIN-AI/OpenSIN-backend) — Backend
+- [OpenSIN-Infrastructure](https://github.com/OpenSIN-AI/OpenSIN-Infrastructure) — Deploy
+- [Global Dev Docs Standard](https://github.com/OpenSIN-AI/Global-Dev-Docs-Standard) — Docs


### PR DESCRIPTION
This PR adds the Global Dev Docs Standard link and cross-repo links to the README.