### PR TITLE
chore(consolidation): absorb OpenSIN-onboarding as user-onboarding/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,51 @@
+# Infra-SIN-Setup
+
+> **Single source of truth for setting up OpenSIN — developer environments AND end-user first-run.**
+>
+> Renamed focus after April 2026 consolidation: this repo now covers *both* audiences that were previously split across `Infra-SIN-Dev-Setup` and the standalone `OpenSIN-onboarding` repo.
+
+## Two entry points
+
+### I am a developer — I want to work on OpenSIN code
+You are in the right place. Read:
+- [macOS-dev-setup.md](./macOS-dev-setup.md)
+- [OCI-dev-setup.md](./OCI-dev-setup.md)
+- [CloudFlare-dev-setup.md](./CloudFlare-dev-setup.md)
+- [OpenCode/OpenCode-dev-setup.md](./OpenCode/OpenCode-dev-setup.md)
+- [opencode-docker-build/](./opencode-docker-build/)
+
+### I am an end user — I just installed OpenSIN and want it to work
+See [`user-onboarding/`](./user-onboarding/). It contains the autonomous first-run scripts that set up:
+
+1. A2A-SIN-Passwordmanager (Google Cloud Secrets backend)
+2. OpenSIN Bridge Chrome Extension (CLI sideload)
+3. API accounts on free-tier platforms (NVIDIA NIM, Groq, Hugging Face, etc.)
+4. `gcloud` service account for secrets management
+5. Seed credentials into the Passwordmanager vault
+
+Entry script: [`user-onboarding/scripts/onboard.sh`](./user-onboarding/scripts/onboard.sh).
+Phases: [`phase1` → `phase6`](./user-onboarding/scripts/).
+
+## Canonical position
+
+This repo is owned by the `Infra-SIN-*` domain in the OpenSIN-AI organization. It is NOT where you write product code — product code lives in:
+
+- [`OpenSIN-AI/OpenSIN`](https://github.com/OpenSIN-AI/OpenSIN) — Python kernel
+- [`OpenSIN-AI/OpenSIN-Code`](https://github.com/OpenSIN-AI/OpenSIN-Code) — autonomous CLI
+- [`OpenSIN-AI/OpenSIN-backend`](https://github.com/OpenSIN-AI/OpenSIN-backend) — control plane
+- [`OpenSIN-AI/Team-SIN-Code-Core`](https://github.com/OpenSIN-AI/Team-SIN-Code-Core) — coding-team monorepo
+
+Full ownership map: [`OpenSIN-overview/docs/CANONICAL-REPOS.md`](https://github.com/OpenSIN-AI/OpenSIN-overview/blob/main/docs/CANONICAL-REPOS.md).
+
+## What moved here in April 2026
+
+`OpenSIN-AI/OpenSIN-onboarding` — a 39 KB standalone repo — was absorbed as `user-onboarding/` and archived. Its whole history is preserved upstream and its source tree is intact here, just one directory deep. Rationale: "set up the dev environment" and "set up the end-user environment" are the same domain with different audiences. Two repos for that was unnecessary and made it unclear where new setup automation should live.
+
+---
+
+<details>
+<summary>Original README (preserved verbatim)</summary>
+
 <a name="readme-top"></a>
 
 # Infra-SIN-Dev-Setup
@@ -317,3 +365,5 @@ Distributed under the **MIT License**. See [LICENSE](LICENSE) for more informati
 </p>
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+</details>

--- a/user-onboarding/.gitignore
+++ b/user-onboarding/.gitignore
@@ -1,0 +1,12 @@
+*.json.bak
+*.stale.*
+.env
+.env.local
+auth/
+token.json
+credentials.db
+service_account.json
+__pycache__/
+*.pyc
+node_modules/
+.DS_Store

--- a/user-onboarding/.well-known/agent-card.json
+++ b/user-onboarding/.well-known/agent-card.json
@@ -1,0 +1,45 @@
+{
+  "name": "OpenSIN Onboarding",
+  "description": "Autonomous first-run onboarding for OpenSIN — sets up Passwordmanager, Google Cloud Secrets, Chrome Extension, API keys, and platform accounts with zero manual intervention",
+  "url": "https://github.com/OpenSIN-AI/OpenSIN-onboarding",
+  "version": "1.0.0",
+  "provider": {
+    "organization": "OpenSIN-AI"
+  },
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false
+  },
+  "skills": [
+    {
+      "id": "onboarding.system-bootstrap",
+      "name": "System Bootstrap",
+      "description": "Verify and install system prerequisites (Node.js, Python, gcloud, Chrome)"
+    },
+    {
+      "id": "onboarding.gcp-setup",
+      "name": "GCP Project Setup",
+      "description": "Create GCP project, enable Secret Manager, create service account"
+    },
+    {
+      "id": "onboarding.passwordmanager",
+      "name": "Passwordmanager Setup",
+      "description": "Build and configure A2A-SIN-Passwordmanager with gcloud backend"
+    },
+    {
+      "id": "onboarding.chrome-extension",
+      "name": "Chrome Extension Install",
+      "description": "Install OpenSIN Bridge Chrome extension"
+    },
+    {
+      "id": "onboarding.platform-accounts",
+      "name": "Platform Registration",
+      "description": "Register accounts on Groq, NVIDIA NIM, Hugging Face and store API keys"
+    },
+    {
+      "id": "onboarding.verification",
+      "name": "Verification",
+      "description": "Run end-to-end health checks on all onboarding components"
+    }
+  ]
+}

--- a/user-onboarding/README.md
+++ b/user-onboarding/README.md
@@ -1,0 +1,229 @@
+# OpenSIN Onboarding
+
+> [!IMPORTANT]
+> **SSOT:** Die kanonische OpenCode-Konfiguration liegt unter [Delqhi/upgraded-opencode-stack](https://github.com/Delqhi/upgraded-opencode-stack).
+> Nach jeder Änderung MUSS `sin-sync` ausgeführt werden.
+
+**Autonomous first-run setup for OpenSIN — zero manual intervention.**
+
+When a new user runs OpenSIN for the first time, this onboarding system automatically:
+
+1. **Installs & configures the A2A-SIN-Passwordmanager** with Google Cloud Secrets backend
+2. **Installs OpenSIN Bridge** Chrome Extension via CLI sideload
+3. **Registers API accounts** on free-tier platforms (NVIDIA NIM, Groq, Hugging Face, etc.)
+4. **Provisions gcloud service account** for secrets management
+5. **Seeds initial credentials** into the Passwordmanager vault
+
+## Architecture
+
+```
+User runs: opensin init
+            │
+            ▼
+┌─────────────────────────────┐
+│  Phase 0: Bun Install ⚡   │
+│  ─ brew install oven-sh/bun/bun │
+│  ─ NEVER npm or npx!       │
+└──────────┬──────────────────┘
+           │
+           ▼
+┌─────────────────────────────┐
+│  Phase 1: System Bootstrap  │
+│  ─ gcloud CLI install       │
+│  ─ Bun verify (NOT npm!)    │
+│  ─ Chrome verify             │
+│  ─ opencode CLI verify       │
+└──────────┬──────────────────┘
+           │
+           ▼
+┌─────────────────────────────┐
+│  Phase 2: GCP Project Setup │
+│  ─ gcloud auth login (CDP)  │
+│  ─ Create GCP project       │
+│  ─ Enable Secret Manager API│
+│  ─ Create service account   │
+│  ─ Generate & store SA key  │
+└──────────┬──────────────────┘
+           │
+           ▼
+┌─────────────────────────────┐
+│  Phase 3: Passwordmanager   │
+│  ─ Build from source        │
+│  ─ Configure gcloud backend │
+│  ─ Verify health check      │
+│  ─ Symlink CLI (spm)        │
+└──────────┬──────────────────┘
+           │
+           ▼
+┌─────────────────────────────┐
+│  Phase 4: Chrome Extension  │
+│  ─ Build extension           │
+│  ─ Sideload via chrome CLI  │
+│  ─ Verify extension active  │
+└──────────┬──────────────────┘
+           │
+           ▼
+┌─────────────────────────────┐
+│  Phase 5: Platform Accounts │
+│  ─ Groq (free vision API)   │
+│  ─ NVIDIA NIM (free tier)   │
+│  ─ Hugging Face (spaces)    │
+│  ─ Store all keys in PM     │
+└──────────┬──────────────────┘
+           │
+           ▼
+┌─────────────────────────────┐
+│  Phase 5.5: Cloud Storage    │
+│  ─ Box.com account creation │
+│  ─ Create Public/Cache folders │
+│  ─ Enable sharing (public links)│
+│  ─ Optional: Developer Token │
+└──────────┬──────────────────┘
+           │
+           ▼
+┌─────────────────────────────┐
+│  Phase 6: Verification      │
+│  ─ PM health check          │
+│  ─ gcloud secrets list      │
+│  ─ Extension ping           │
+│  ─ API key validation       │
+│  ─ Print onboarding report  │
+└─────────────────────────────┘
+```
+
+## Cloud Storage Integration
+
+OpenSIN uses **Box.com** (10 GB free) as primary cloud storage, replacing GitLab Storage (account banned).
+
+### Storage Layout
+
+| Folder | Purpose | Sharing |
+|--------|---------|---------|
+| `/OpenSIN-Public` | Logos, images, docs (publicly accessible) | "People with link" → Can view |
+| `/OpenSIN-Cache` | Logs, cache, temporary files | "People with link" → Can view |
+
+### User Onboarding Flow
+
+During `opensin init`, users are guided through:
+
+1. **Create Box.com account** (free 10 GB)
+2. **Create folders** `/OpenSIN-Public` and `/OpenSIN-Cache`
+3. **Enable sharing** (public links must work, otherwise 404!)
+4. **Optional:** Create Box Developer Token for API access
+
+### Important Notes
+
+- **GitLab Storage is DEAD** — all previous GitLab-based log/cache uploads are migrated to Box.com
+- **Public links must be enabled** — without "People with the link" sharing, URLs return 404
+- **Developer Token** (optional) allows programmatic uploads via Box API
+- **Alternative:** Google Drive (15 GB free) can be used instead for user data
+
+### Configuration
+
+After onboarding, users should:
+
+1. Get folder IDs from Box.com (`box folders:children 0`)
+2. Add to `.env`:
+   ```bash
+   BOX_PUBLIC_FOLDER_ID=<id>
+   BOX_CACHE_FOLDER_ID=<id>
+   BOX_DEVELOPER_TOKEN=<token>
+   ```
+3. Share the public links with the OpenSIN team
+
+### Default Public Links (Example)
+
+- Public: https://app.box.com/s/1st624o9eb5xdistusew5w0erb8offc7
+- Cache: https://app.box.com/s/9s5htoefw1ux9ajaqj656v9a02h7z7x1
+
+**⚠️ These links only work if sharing is properly configured!**
+
+## Quick Start
+
+```bash
+git clone https://github.com/OpenSIN-AI/OpenSIN-onboarding.git
+cd OpenSIN-onboarding
+./scripts/onboard.sh
+```
+
+Or via OpenSIN CLI:
+
+```bash
+opensin init
+```
+
+## Directory Structure
+
+```
+OpenSIN-onboarding/
+├── scripts/
+│   ├── onboard.sh                  # Main entry point
+│   ├── phase1_system_bootstrap.sh  # System prerequisites
+│   ├── phase2_gcp_setup.sh         # GCP project + service account
+│   ├── phase3_passwordmanager.sh   # PM build + configure
+│   ├── phase4_chrome_extension.sh  # Extension sideload
+│   ├── phase5_platform_accounts.py # Autonomous account registration
+│   └── phase6_verification.sh      # End-to-end health checks
+├── docs/
+│   ├── 01-prerequisites.md         # What users need before starting
+│   ├── 02-passwordmanager-setup.md # Deep dive: PM + GCS architecture
+│   ├── 03-chrome-extension.md      # Extension installation details
+│   ├── 04-platform-accounts.md     # Platform registration reference
+│   ├── 05-troubleshooting.md       # Common issues + fixes
+│   └── 06-security-model.md        # How secrets are protected
+├── config/
+│   └── templates/
+│       ├── catalog.template.json   # PM catalog seed template
+│       └── env.template            # Environment variable template
+├── .well-known/
+│   └── agent-card.json             # A2A discovery card
+└── README.md
+```
+
+## Supported Platforms (Auto-Registration)
+
+| Platform | Free Tier | What OpenSIN Uses It For |
+|----------|-----------|--------------------------|
+| **Google Cloud** | $300 credit + always-free Secret Manager (6 active versions) | Passwordmanager backend (Google Cloud Secrets) |
+| **Groq** | 14,400 req/day (vision models) | OpenSIN Bridge vision analysis |
+| **NVIDIA NIM** | 1,000 free API calls/month | Specialized AI models (Qwen, Cosmos) |
+| **Hugging Face** | Unlimited free CPU Spaces | A2A agent hosting |
+| **GitHub** | Unlimited public repos | Code hosting, Issues, A2A coordination |
+
+## How Autonomous Registration Works
+
+OpenSIN uses the **Two-Layer Browser Stack** (nodriver + CDP) to:
+
+1. Navigate to platform signup page
+2. Fill registration forms with user-provided email
+3. Handle email verification via user's mail client
+4. Extract API keys from dashboard
+5. Store keys in Passwordmanager (Google Cloud Secrets)
+
+The user only needs to provide:
+- **Email address** (for account registration)
+- **Google account** (for GCP + Chrome profile)
+
+Everything else is fully autonomous.
+
+## Security Model
+
+- All secrets stored in **Google Cloud Secret Manager** (encrypted at rest with Google-managed keys)
+- Service account key stored locally at `~/.config/opencode/auth/google/` with `600` permissions
+- No secrets ever committed to git (enforced by `.gitignore` + pre-commit hooks)
+- Secret names follow pattern: `spm-{name}` in GCP
+- Passwordmanager catalog (metadata only, no values) at `~/.config/sin/sin-passwordmanager/catalog.json`
+
+## Related Repositories
+
+| Repository | Purpose |
+|-----------|---------|
+| [OpenSIN-backend](https://github.com/OpenSIN-AI/OpenSIN-backend) | A2A-SIN-Passwordmanager source code |
+| [OpenSIN-documentation](https://github.com/OpenSIN-AI/OpenSIN-documentation) | Full platform docs (docs.opensin.ai) |
+| [OpenSIN-overview](https://github.com/OpenSIN-AI/OpenSIN-overview) | Organization SSOT registry |
+| [OpenSIN](https://github.com/OpenSIN-AI/OpenSIN) | Core platform |
+| [OpenSIN-Code](https://github.com/OpenSIN-AI/OpenSIN-Code) | CLI tool |
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE)

--- a/user-onboarding/config/templates/catalog.template.json
+++ b/user-onboarding/config/templates/catalog.template.json
@@ -1,0 +1,4 @@
+{
+  "secrets": [],
+  "version": 1
+}

--- a/user-onboarding/config/templates/env.template
+++ b/user-onboarding/config/templates/env.template
@@ -1,0 +1,2 @@
+SPM_SECRET_BACKEND=gcloud
+SPM_GCLOUD_PROJECT=your-gcp-project-id

--- a/user-onboarding/docs/01-prerequisites.md
+++ b/user-onboarding/docs/01-prerequisites.md
@@ -1,0 +1,41 @@
+# Prerequisites
+
+Before running the OpenSIN onboarding, ensure you have:
+
+## Required
+
+| Requirement | Minimum Version | Install |
+|------------|----------------|---------|
+| **macOS** | 12+ (Monterey) | — |
+| **Bun** | 1.3+ (ERSTER Schritt!) | `brew install oven-sh/bun/bun` |
+| **Node.js** | 18+ | `brew install node` |
+| **Python** | 3.11+ | `brew install python3` |
+| **Git** | 2.30+ | `brew install git` |
+| **Google Chrome** | 120+ | [Download](https://www.google.com/chrome/) |
+| **GitHub CLI** | 2.0+ | `brew install gh` |
+
+> ⚠️ **ACHTUNG:** Bun MUSS vor allen anderen Schritten installiert werden. `npm` und `npx` sind im OpenSIN-Ökosystem PERMANENT VERBOTEN (OOM-Killer crasht den Mac). Verwende AUSSCHLIESSLICH `bun install`, `bun run`, `bunx`.
+
+## Required Accounts
+
+| Account | Purpose | Sign Up |
+|---------|---------|---------|
+| **Google Account** | GCP project for Secret Manager | [accounts.google.com](https://accounts.google.com) |
+| **GitHub Account** | Code hosting, A2A coordination | [github.com/signup](https://github.com/signup) |
+
+## Optional (Auto-Registered During Onboarding)
+
+| Account | Purpose | Free Tier |
+|---------|---------|-----------|
+| **Groq** | Vision models for OpenSIN Bridge | 14,400 req/day |
+| **NVIDIA NIM** | Specialized AI models | 1,000 calls/month |
+| **Hugging Face** | A2A agent hosting | Unlimited CPU Spaces |
+
+## Pre-Flight Check
+
+```bash
+node --version    # Must be 18+
+python3 --version # Must be 3.11+
+git --version     # Must be 2.30+
+gh auth status    # Must be logged in
+```

--- a/user-onboarding/docs/02-passwordmanager-setup.md
+++ b/user-onboarding/docs/02-passwordmanager-setup.md
@@ -1,0 +1,107 @@
+# Passwordmanager + Google Cloud Secrets Setup
+
+The **A2A-SIN-Passwordmanager** is the central secrets authority for the entire OpenSIN ecosystem. Every agent, extension, and service retrieves credentials through it.
+
+## Architecture
+
+```
+┌──────────────────────┐
+│   A2A Agent / CLI    │
+│   "spm run-action"   │
+└──────────┬───────────┘
+           │ JSON-RPC
+           ▼
+┌──────────────────────┐
+│  SIN-Passwordmanager │
+│  (Node.js runtime)   │
+│                      │
+│  Backends:           │
+│  ├── gcloud (default)│ ──→ Google Cloud Secret Manager
+│  ├── keychain        │ ──→ macOS Keychain
+│  └── file            │ ──→ AES-256-GCM encrypted file
+└──────────────────────┘
+```
+
+## Backend: Google Cloud Secrets (Default)
+
+The `gcloud` backend stores each secret as a Google Cloud Secret Manager resource:
+
+- **Secret naming**: `spm-{name}` (e.g., `GROQ_API_KEY_1` → `spm-groq_api_key_1`)
+- **Encryption**: Google-managed AES-256 at rest
+- **Replication**: Automatic (multi-region)
+- **Free tier**: 6 active secret versions, 10,000 access operations/month
+- **Project**: User's own GCP project (created during onboarding)
+
+### Service Account
+
+The Passwordmanager authenticates via a GCP service account:
+
+| Field | Value |
+|-------|-------|
+| **Account** | `opensin-agent@{project}.iam.gserviceaccount.com` |
+| **Role** | `roles/secretmanager.admin` |
+| **Key file** | `~/.config/opencode/auth/google/service-account.json` |
+| **Permissions** | `600` (owner read/write only) |
+
+### Key Rotation
+
+If the service account key is compromised or expired:
+
+```bash
+GCLOUD=/opt/homebrew/Caskroom/gcloud-cli/*/google-cloud-sdk/bin/gcloud
+
+# 1. Authenticate as user (not SA)
+$GCLOUD auth login --no-launch-browser
+
+# 2. Create new key
+$GCLOUD iam service-accounts keys create /tmp/new-key.json \
+  --iam-account=opensin-agent@YOUR_PROJECT.iam.gserviceaccount.com
+
+# 3. Install and activate
+cp /tmp/new-key.json ~/.config/opencode/auth/google/service-account.json
+chmod 600 ~/.config/opencode/auth/google/service-account.json
+$GCLOUD auth activate-service-account --key-file=~/.config/opencode/auth/google/service-account.json
+
+# 4. Verify
+$GCLOUD secrets list --project=YOUR_PROJECT
+
+# 5. Clean up
+rm /tmp/new-key.json
+```
+
+## CLI Usage
+
+```bash
+export SPM_SECRET_BACKEND=gcloud
+
+# Health check
+spm run-action '{"action":"sin.passwordmanager.health"}'
+
+# Store a secret
+spm run-action '{"action":"sin.passwordmanager.secret.put","name":"MY_KEY","value":"sk-...","description":"My API key","tags":["auth"]}'
+
+# Retrieve (masked)
+spm run-action '{"action":"sin.passwordmanager.secret.get","name":"MY_KEY"}'
+
+# Retrieve (revealed)
+spm run-action '{"action":"sin.passwordmanager.secret.get","name":"MY_KEY","reveal":true}'
+
+# List all secrets
+spm run-action '{"action":"sin.passwordmanager.secret.list"}'
+
+# Delete
+spm run-action '{"action":"sin.passwordmanager.secret.delete","name":"MY_KEY"}'
+```
+
+## Catalog
+
+The catalog at `~/.config/sin/sin-passwordmanager/catalog.json` stores **metadata only** (names, descriptions, tags, targets). Secret **values** are never stored locally — they live exclusively in Google Cloud Secret Manager.
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Invalid JWT Signature` | SA key was rotated/revoked on Google's side | Follow key rotation steps above |
+| `PERMISSION_DENIED` | SA lacks `secretmanager.admin` role | Re-run `gcloud projects add-iam-policy-binding` |
+| `Secret not found` | Secret doesn't exist in GCP | Create with `secret.put` action |
+| `undefined` output | Wrong action name (e.g., `set` instead of `secret.put`) | Use full action name: `sin.passwordmanager.secret.put` |

--- a/user-onboarding/docs/03-chrome-extension.md
+++ b/user-onboarding/docs/03-chrome-extension.md
@@ -1,0 +1,79 @@
+# OpenSIN Bridge Chrome Extension
+
+OpenSIN Bridge is the Chrome extension that gives AI agents eyes and hands in the browser — CDP-based vision analysis, page inspection, and action execution.
+
+## What It Does
+
+| Capability | Tools | Description |
+|-----------|-------|-------------|
+| **CDP Agent Vision** | 9 tools | Screenshot, DOM inspection, JS execution, network monitoring |
+| **Multi-Provider Vision** | 4 tools | AI-powered image analysis via Gemini + Groq fallback chain |
+| **Security** | 36 hardening fixes | CSP headers, input sanitization, origin verification |
+| **Tab Management** | Tab CRUD | Create, navigate, close, list tabs |
+
+## Vision Provider Chain
+
+The extension tries providers in order until one succeeds:
+
+| Priority | Provider | Model | Free Tier |
+|----------|----------|-------|-----------|
+| 1 | Gemini | gemini-2.5-flash | 500 req/day |
+| 2 | Gemini | gemini-1.5-flash | 1,500 req/day |
+| 3 | Gemini | gemini-3-flash-preview | 500 req/day |
+| 4 | Groq | llama-3.2-11b-vision | 14,400 req/day |
+| 5 | Groq | llama-4-scout-17b | 1,000 req/day |
+| 6 | Groq | llama-3.2-90b-vision | 1,000 req/day |
+| 7 | Gemini | gemini-2.5-pro | 25 req/day |
+
+**Total free capacity: ~18,000+ vision requests/day**
+
+## Installation
+
+### During Onboarding (Automatic)
+
+The onboarding script (`phase4_chrome_extension.sh`) copies the extension files to `~/.config/sin/opensin-bridge/` and provides instructions for loading.
+
+### Manual Installation
+
+1. Open Chrome → `chrome://extensions`
+2. Enable **Developer mode** (top-right toggle)
+3. Click **Load unpacked**
+4. Select folder: `~/.config/sin/opensin-bridge/`
+5. Pin the extension icon in the toolbar
+
+### CLI-Based Loading
+
+```bash
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --load-extension="$HOME/.config/sin/opensin-bridge" \
+  --remote-debugging-port=9335
+```
+
+## API Key Configuration
+
+The extension needs at least one vision API key. During onboarding, keys are stored in the Passwordmanager. The extension reads them from:
+
+1. **Extension storage** (set via popup or `chrome.storage.sync`)
+2. **Hardcoded fallback** in `service_worker.js` (populated during onboarding)
+
+To set keys manually:
+
+```javascript
+chrome.storage.sync.set({
+  groqApiKey: "gsk_...",
+  geminiApiKey: "AIzaSy..."
+});
+```
+
+## Extension ID
+
+After loading, the extension gets a unique ID. You can find it at `chrome://extensions`. Use this ID in your `opencode.json` MCP configuration to connect the extension to OpenSIN agents.
+
+## Updating
+
+```bash
+cd ~/.config/sin/opensin-bridge
+git pull origin main
+```
+
+Then reload the extension in `chrome://extensions` (click the refresh icon).

--- a/user-onboarding/docs/04-platform-accounts.md
+++ b/user-onboarding/docs/04-platform-accounts.md
@@ -1,0 +1,90 @@
+# Platform Account Registration
+
+OpenSIN autonomously registers accounts on free-tier AI platforms so you don't have to. This document covers each platform and what OpenSIN uses it for.
+
+## Registration Flow
+
+```
+User provides: email + Google account
+         │
+         ▼
+OpenSIN Browser Automation (CDP + nodriver)
+         │
+         ├── Navigate to signup page
+         ├── Fill registration form
+         ├── Handle email verification
+         ├── Extract API key from dashboard
+         └── Store key in Passwordmanager (GCS)
+```
+
+## Supported Platforms
+
+### Groq
+
+| Field | Value |
+|-------|-------|
+| **URL** | [console.groq.com](https://console.groq.com) |
+| **Free Tier** | 14,400 requests/day (vision models) |
+| **Used For** | OpenSIN Bridge vision analysis (llama-3.2-11b-vision, llama-4-scout) |
+| **PM Key Name** | `GROQ_API_KEY` |
+| **Signup** | Email + password, email verification |
+
+**Why Groq?** Groq provides the highest free-tier rate limit for vision models — 14,400 requests/day is enough for continuous agent operation without hitting limits.
+
+### NVIDIA NIM
+
+| Field | Value |
+|-------|-------|
+| **URL** | [build.nvidia.com](https://build.nvidia.com) |
+| **Free Tier** | 1,000 API calls/month |
+| **Used For** | Specialized models (Qwen 3.5, Cosmos video, Llama variants) |
+| **PM Key Name** | `NVIDIA_API_KEY` |
+| **Signup** | NVIDIA Developer account (email + profile) |
+
+**Why NVIDIA NIM?** Access to bleeding-edge models (Qwen 3.5 397B, Cosmos video generation) that aren't available elsewhere for free.
+
+### Hugging Face
+
+| Field | Value |
+|-------|-------|
+| **URL** | [huggingface.co](https://huggingface.co) |
+| **Free Tier** | Unlimited CPU-basic Spaces ($0/month) |
+| **Used For** | A2A agent hosting, model inference, dataset storage |
+| **PM Key Name** | `HUGGINGFACE_TOKEN` |
+| **Signup** | Email + username |
+
+**Why Hugging Face?** Unlimited free CPU Spaces means we can deploy unlimited A2A agents at zero cost. Each agent gets its own Space with Docker support.
+
+### GitHub
+
+| Field | Value |
+|-------|-------|
+| **URL** | [github.com](https://github.com) |
+| **Free Tier** | Unlimited public repos, 2,000 Actions minutes/month |
+| **Used For** | Code hosting, Issues (bug library), A2A coordination, PR workflows |
+| **PM Key Name** | `GITHUB_TOKEN` |
+| **Auto-Detection** | If `gh auth status` succeeds, the token is extracted automatically |
+
+## Manual Key Storage
+
+If autonomous registration isn't possible (e.g., platform requires CAPTCHA), store keys manually:
+
+```bash
+spm run-action '{
+  "action": "sin.passwordmanager.secret.put",
+  "name": "GROQ_API_KEY",
+  "value": "gsk_your_key_here",
+  "description": "Groq API key for vision models",
+  "tags": ["auth", "groq", "vision", "free-tier"]
+}'
+```
+
+## Future Platforms
+
+| Platform | Status | Use Case |
+|----------|--------|----------|
+| **Cloudflare** | Planned | Workers for edge compute, Pages for hosting |
+| **Vercel** | Planned | Dashboard and web app hosting |
+| **Google AI Studio** | Planned | Gemini API keys |
+| **Anthropic** | Planned | Claude API (when free tier available) |
+| **OpenAI** | Planned | GPT API access |

--- a/user-onboarding/docs/05-troubleshooting.md
+++ b/user-onboarding/docs/05-troubleshooting.md
@@ -1,0 +1,77 @@
+# Troubleshooting
+
+## Common Issues
+
+### Phase 2: GCP Setup
+
+**Error: `Invalid JWT Signature`**
+
+The service account key was rotated or revoked on Google's side (often because it was exposed in a git commit).
+
+Fix:
+1. Login as user: `gcloud auth login --no-launch-browser`
+2. Create new key: `gcloud iam service-accounts keys create /tmp/new-key.json --iam-account=SA_EMAIL`
+3. Replace: `cp /tmp/new-key.json ~/.config/opencode/auth/google/service-account.json`
+4. Activate: `gcloud auth activate-service-account --key-file=~/.config/opencode/auth/google/service-account.json`
+
+**Error: `Project creation failed`**
+
+Google Cloud requires billing to create new projects. Either:
+- Enable billing at [console.cloud.google.com/billing](https://console.cloud.google.com/billing)
+- Or use an existing project: `gcloud config set project YOUR_PROJECT`
+
+### Phase 3: Passwordmanager
+
+**Output: `undefined` from run-action**
+
+Wrong action name format. The correct patterns are:
+- `sin.passwordmanager.secret.put` (not `set`)
+- `sin.passwordmanager.secret.get` (not `get`)
+- Parameters go at the top level, not nested under `input`
+
+**Error: `Cannot find module`**
+
+The TypeScript hasn't been built. Run:
+```bash
+cd ~/.config/sin/sin-passwordmanager/build
+npm install && npx tsc
+```
+
+### Phase 4: Chrome Extension
+
+**Extension not loading**
+
+1. Verify files exist: `ls ~/.config/sin/opensin-bridge/manifest.json`
+2. Check Chrome version: must be 120+
+3. Ensure Developer Mode is ON in `chrome://extensions`
+4. Check for errors in `chrome://extensions` (red error badge)
+
+**Vision not working**
+
+1. Check API keys are set in extension storage
+2. Open service worker DevTools from `chrome://extensions`
+3. Check console for rate limit or auth errors
+
+### Phase 5: Platform Registration
+
+**Can't auto-register (CAPTCHA)**
+
+Some platforms use CAPTCHAs that block automated signup. In this case:
+1. Register manually at the platform URL
+2. Copy your API key
+3. Store via: `spm run-action '{"action":"sin.passwordmanager.secret.put","name":"KEY_NAME","value":"your_key"}'`
+
+## Reset & Re-Run
+
+To reset onboarding state and re-run from scratch:
+
+```bash
+rm ~/.config/sin/onboarding-state.json
+./scripts/onboard.sh
+```
+
+To re-run a specific phase:
+
+```bash
+bash scripts/phase3_passwordmanager.sh
+```

--- a/user-onboarding/docs/06-security-model.md
+++ b/user-onboarding/docs/06-security-model.md
@@ -1,0 +1,59 @@
+# Security Model
+
+## Secrets Storage
+
+All secrets are stored in **Google Cloud Secret Manager** (GCS):
+
+| Property | Value |
+|----------|-------|
+| **Encryption at rest** | AES-256 (Google-managed keys) |
+| **Encryption in transit** | TLS 1.3 |
+| **Replication** | Automatic multi-region |
+| **Access control** | IAM-based (service account with `secretmanager.admin`) |
+| **Audit logging** | Cloud Audit Logs (data access + admin activity) |
+
+## Local Files
+
+| File | Contents | Permissions |
+|------|----------|-------------|
+| `~/.config/opencode/auth/google/service-account.json` | SA private key (most sensitive) | `600` |
+| `~/.config/sin/sin-passwordmanager/catalog.json` | Secret metadata (names, tags — no values) | `644` |
+| `~/.config/sin/onboarding-state.json` | Phase completion timestamps | `644` |
+
+## What Is Never Stored Locally
+
+- Secret **values** (only in GCS)
+- OAuth refresh tokens (handled by gcloud CLI)
+- Platform passwords (only API keys stored)
+
+## Git Safety
+
+The following patterns are excluded from all OpenSIN repos:
+
+```gitignore
+*.json.bak
+**/auth/google/*.json
+**/service_account.json
+**/.env
+**/.env.local
+**/token.json
+**/credentials.db
+```
+
+## Service Account Key Lifecycle
+
+1. **Created** during onboarding (Phase 2)
+2. **Stored** at `~/.config/opencode/auth/google/service-account.json` with `600` permissions
+3. **Never committed** to any git repository
+4. **Rotated** when compromised using `gcloud iam service-accounts keys create`
+5. **Old keys** are renamed to `.stale.TIMESTAMP.bak` and should be deleted after verification
+
+## Threat Model
+
+| Threat | Mitigation |
+|--------|-----------|
+| Key committed to public repo | Google auto-disables exposed keys; rotation procedure documented |
+| Local machine compromised | Key file has `600` permissions; values only in GCS |
+| GCS compromised | Google's infrastructure security; IAM access controls |
+| Man-in-the-middle | TLS 1.3 for all GCS API calls |
+| Unauthorized agent access | Each agent authenticates via the same SA; future: per-agent SA |

--- a/user-onboarding/scripts/onboard.sh
+++ b/user-onboarding/scripts/onboard.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log()  { echo -e "${GREEN}[✓]${NC} $*"; }
+warn() { echo -e "${YELLOW}[!]${NC} $*"; }
+err()  { echo -e "${RED}[✗]${NC} $*"; }
+info() { echo -e "${BLUE}[→]${NC} $*"; }
+
+ONBOARD_STATE="$HOME/.config/sin/onboarding-state.json"
+
+save_state() {
+  local phase="$1" status="$2"
+  mkdir -p "$(dirname "$ONBOARD_STATE")"
+  python3 -c "
+import json, os, datetime
+path = '$ONBOARD_STATE'
+state = {}
+if os.path.exists(path):
+    with open(path) as f: state = json.load(f)
+state['$phase'] = {'status': '$status', 'timestamp': datetime.datetime.utcnow().isoformat() + 'Z'}
+with open(path, 'w') as f: json.dump(state, f, indent=2)
+"
+}
+
+check_phase_done() {
+  local phase="$1"
+  if [ -f "$ONBOARD_STATE" ]; then
+    python3 -c "
+import json, sys
+with open('$ONBOARD_STATE') as f: state = json.load(f)
+sys.exit(0 if state.get('$phase', {}).get('status') == 'completed' else 1)
+" 2>/dev/null && return 0
+  fi
+  return 1
+}
+
+echo ""
+echo "╔══════════════════════════════════════════════════════════════╗"
+echo "║            OpenSIN — Autonomous Onboarding v1.0            ║"
+echo "║        Zero manual intervention. Fully autonomous.         ║"
+echo "╚══════════════════════════════════════════════════════════════╝"
+echo ""
+
+if check_phase_done "phase1"; then
+  log "Phase 1 already completed, skipping..."
+else
+  info "Phase 1: System Bootstrap"
+  bash "$SCRIPT_DIR/phase1_system_bootstrap.sh"
+  save_state "phase1" "completed"
+fi
+
+if check_phase_done "phase2"; then
+  log "Phase 2 already completed, skipping..."
+else
+  info "Phase 2: GCP Project + Service Account"
+  bash "$SCRIPT_DIR/phase2_gcp_setup.sh"
+  save_state "phase2" "completed"
+fi
+
+if check_phase_done "phase3"; then
+  log "Phase 3 already completed, skipping..."
+else
+  info "Phase 3: Passwordmanager Setup"
+  bash "$SCRIPT_DIR/phase3_passwordmanager.sh"
+  save_state "phase3" "completed"
+fi
+
+if check_phase_done "phase4"; then
+  log "Phase 4 already completed, skipping..."
+else
+  info "Phase 4: Chrome Extension Install"
+  bash "$SCRIPT_DIR/phase4_chrome_extension.sh"
+  save_state "phase4" "completed"
+fi
+
+if check_phase_done "phase5"; then
+  log "Phase 5 already completed, skipping..."
+else
+  info "Phase 5: Platform Account Registration"
+  python3 "$SCRIPT_DIR/phase5_platform_accounts.py"
+  save_state "phase5" "completed"
+fi
+
+if check_phase_done "phase5_storage"; then
+  log "Phase 5.5 already completed, skipping..."
+else
+  info "Phase 5.5: Cloud Storage Setup"
+  bash "$SCRIPT_DIR/phase5_storage_setup.sh"
+  save_state "phase5_storage" "completed"
+fi
+
+info "Phase 6: Verification"
+bash "$SCRIPT_DIR/phase6_verification.sh"
+save_state "phase6" "completed"
+
+echo ""
+echo "╔══════════════════════════════════════════════════════════════╗"
+echo "║              ✅ OpenSIN Onboarding Complete!                ║"
+echo "║                                                            ║"
+echo "║  Passwordmanager:  gcloud backend active                   ║"
+echo "║  Chrome Extension: OpenSIN Bridge installed                ║"
+echo "║  Platform Keys:    Stored in Google Cloud Secrets          ║"
+echo "║                                                            ║"
+echo "║  Run 'opensin status' to verify your setup anytime.        ║"
+echo "╚══════════════════════════════════════════════════════════════╝"
+echo ""

--- a/user-onboarding/scripts/phase1_system_bootstrap.sh
+++ b/user-onboarding/scripts/phase1_system_bootstrap.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GREEN='\033[0;32m'; RED='\033[0;31m'; BLUE='\033[0;34m'; NC='\033[0m'
+log()  { echo -e "${GREEN}[✓]${NC} $*"; }
+err()  { echo -e "${RED}[✗]${NC} $*"; exit 1; }
+info() { echo -e "${BLUE}[→]${NC} $*"; }
+
+info "Checking system prerequisites..."
+
+# Node.js
+if command -v node &>/dev/null; then
+  NODE_VER=$(node --version)
+  log "Node.js: $NODE_VER"
+  NODE_MAJOR=$(echo "$NODE_VER" | sed 's/v//' | cut -d. -f1)
+  [ "$NODE_MAJOR" -lt 18 ] && err "Node.js 18+ required (found $NODE_VER). Install via: brew install node"
+else
+  err "Node.js not found. Install via: brew install node"
+fi
+
+# npm
+command -v npm &>/dev/null && log "npm: $(npm --version)" || err "npm not found"
+
+# Python 3
+if command -v python3 &>/dev/null; then
+  log "Python3: $(python3 --version)"
+else
+  err "Python3 not found. Install via: brew install python3"
+fi
+
+# Git
+command -v git &>/dev/null && log "Git: $(git --version | cut -d' ' -f3)" || err "Git not found"
+
+# gh CLI
+command -v gh &>/dev/null && log "GitHub CLI: $(gh --version | head -1 | awk '{print $3}')" || err "GitHub CLI not found. Install via: brew install gh"
+
+# Chrome
+CHROME_APP="/Applications/Google Chrome.app"
+if [ -d "$CHROME_APP" ]; then
+  CHROME_VER=$("$CHROME_APP/Contents/MacOS/Google Chrome" --version 2>/dev/null | awk '{print $NF}')
+  log "Chrome: $CHROME_VER"
+else
+  err "Google Chrome not found at $CHROME_APP"
+fi
+
+# gcloud CLI
+GCLOUD_PATHS=(
+  "/opt/homebrew/Caskroom/gcloud-cli/*/google-cloud-sdk/bin/gcloud"
+  "/usr/local/Caskroom/gcloud-cli/*/google-cloud-sdk/bin/gcloud"
+  "$HOME/google-cloud-sdk/bin/gcloud"
+)
+GCLOUD=""
+for pattern in "${GCLOUD_PATHS[@]}"; do
+  for match in $pattern; do
+    [ -x "$match" ] && GCLOUD="$match" && break 2
+  done
+done
+
+if [ -n "$GCLOUD" ]; then
+  log "gcloud CLI: $($GCLOUD --version 2>/dev/null | head -1 | awk '{print $4}')"
+else
+  info "gcloud CLI not found — installing via Homebrew..."
+  if command -v brew &>/dev/null; then
+    brew install --cask google-cloud-sdk
+    GCLOUD="/opt/homebrew/Caskroom/gcloud-cli/$(ls /opt/homebrew/Caskroom/gcloud-cli/ | head -1)/google-cloud-sdk/bin/gcloud"
+    log "gcloud CLI installed: $($GCLOUD --version 2>/dev/null | head -1 | awk '{print $4}')"
+  else
+    err "Neither gcloud nor Homebrew found. Install gcloud manually: https://cloud.google.com/sdk/docs/install"
+  fi
+fi
+
+echo "$GCLOUD" > /tmp/opensin-gcloud-path
+mkdir -p "$HOME/.config/sin"
+
+log "Phase 1 complete — all system prerequisites satisfied"

--- a/user-onboarding/scripts/phase2_gcp_setup.sh
+++ b/user-onboarding/scripts/phase2_gcp_setup.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; BLUE='\033[0;34m'; NC='\033[0m'
+log()  { echo -e "${GREEN}[✓]${NC} $*"; }
+warn() { echo -e "${YELLOW}[!]${NC} $*"; }
+err()  { echo -e "${RED}[✗]${NC} $*"; exit 1; }
+info() { echo -e "${BLUE}[→]${NC} $*"; }
+
+GCLOUD=$(cat /tmp/opensin-gcloud-path 2>/dev/null || echo "gcloud")
+GCP_PROJECT="opensin-$(whoami | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9' | head -c 12)-$(date +%s | tail -c 5)"
+SA_EMAIL="opensin-agent@${GCP_PROJECT}.iam.gserviceaccount.com"
+KEY_DIR="$HOME/.config/opencode/auth/google"
+KEY_FILE="$KEY_DIR/service-account.json"
+
+mkdir -p "$KEY_DIR"
+
+ACTIVE=$($GCLOUD auth list --format="value(account)" --filter="status:ACTIVE" 2>/dev/null || true)
+if [ -z "$ACTIVE" ]; then
+  info "No gcloud account active — starting browser-based OAuth login..."
+
+  if command -v python3 &>/dev/null && python3 -c "import websockets" 2>/dev/null; then
+    OAUTH_OUTPUT=$($GCLOUD auth login --no-launch-browser 2>&1 &
+      GCLOUD_PID=$!
+      sleep 3
+      kill $GCLOUD_PID 2>/dev/null || true
+      wait $GCLOUD_PID 2>/dev/null || true
+    )
+    warn "Automatic CDP login requires Chrome with --remote-debugging-port."
+    warn "Falling back to interactive login..."
+  fi
+
+  $GCLOUD auth login --project="$GCP_PROJECT" --brief 2>&1 || err "gcloud auth login failed"
+fi
+
+ACTIVE=$($GCLOUD auth list --format="value(account)" --filter="status:ACTIVE" 2>/dev/null)
+log "Authenticated as: $ACTIVE"
+
+EXISTING_PROJECT=$($GCLOUD config get-value project 2>/dev/null || true)
+if [ -n "$EXISTING_PROJECT" ] && [ "$EXISTING_PROJECT" != "(unset)" ]; then
+  info "Using existing GCP project: $EXISTING_PROJECT"
+  GCP_PROJECT="$EXISTING_PROJECT"
+  SA_EMAIL="opensin-agent@${GCP_PROJECT}.iam.gserviceaccount.com"
+else
+  info "Creating GCP project: $GCP_PROJECT"
+  $GCLOUD projects create "$GCP_PROJECT" --name="OpenSIN Onboarding" 2>&1 || {
+    warn "Project creation failed (may need billing). Using default project."
+    GCP_PROJECT=$($GCLOUD config get-value project 2>/dev/null)
+    SA_EMAIL="opensin-agent@${GCP_PROJECT}.iam.gserviceaccount.com"
+  }
+  $GCLOUD config set project "$GCP_PROJECT" 2>/dev/null
+fi
+
+log "GCP Project: $GCP_PROJECT"
+
+info "Enabling Secret Manager API..."
+$GCLOUD services enable secretmanager.googleapis.com --project="$GCP_PROJECT" 2>&1 || warn "API enable failed (may already be enabled)"
+log "Secret Manager API enabled"
+
+EXISTING_SA=$($GCLOUD iam service-accounts list --project="$GCP_PROJECT" --format="value(email)" --filter="email:opensin-agent" 2>/dev/null || true)
+if [ -n "$EXISTING_SA" ]; then
+  log "Service account exists: $EXISTING_SA"
+  SA_EMAIL="$EXISTING_SA"
+else
+  info "Creating service account: opensin-agent"
+  $GCLOUD iam service-accounts create opensin-agent \
+    --display-name="OpenSIN Agent" \
+    --description="Service account for OpenSIN Passwordmanager and A2A agents" \
+    --project="$GCP_PROJECT" 2>&1
+  log "Service account created: $SA_EMAIL"
+fi
+
+info "Granting Secret Manager Admin role..."
+$GCLOUD projects add-iam-policy-binding "$GCP_PROJECT" \
+  --member="serviceAccount:$SA_EMAIL" \
+  --role="roles/secretmanager.admin" \
+  --condition=None \
+  --quiet 2>&1 | tail -1
+log "IAM role granted"
+
+if [ -f "$KEY_FILE" ]; then
+  info "Existing key file found, testing validity..."
+  if $GCLOUD auth activate-service-account "$SA_EMAIL" --key-file="$KEY_FILE" --project="$GCP_PROJECT" 2>/dev/null; then
+    log "Existing key is valid"
+  else
+    warn "Existing key is stale, generating new one..."
+    mv "$KEY_FILE" "${KEY_FILE}.stale.$(date +%s).bak"
+    $GCLOUD iam service-accounts keys create "$KEY_FILE" \
+      --iam-account="$SA_EMAIL" --project="$GCP_PROJECT" --key-file-type=json 2>&1
+    $GCLOUD auth activate-service-account "$SA_EMAIL" --key-file="$KEY_FILE" --project="$GCP_PROJECT" 2>&1
+    log "New key generated and activated"
+  fi
+else
+  info "Generating service account key..."
+  $GCLOUD iam service-accounts keys create "$KEY_FILE" \
+    --iam-account="$SA_EMAIL" --project="$GCP_PROJECT" --key-file-type=json 2>&1
+  $GCLOUD auth activate-service-account "$SA_EMAIL" --key-file="$KEY_FILE" --project="$GCP_PROJECT" 2>&1
+  log "Key generated and activated"
+fi
+
+chmod 600 "$KEY_FILE"
+
+cp "$KEY_FILE" "$HOME/.config/google/service_account.json" 2>/dev/null || true
+
+python3 -c "
+import json
+with open('$KEY_FILE') as f: k = json.load(f)
+print(f'  project_id:     {k[\"project_id\"]}')
+print(f'  client_email:   {k[\"client_email\"]}')
+print(f'  private_key_id: {k[\"private_key_id\"][:16]}...')
+"
+
+echo "$GCP_PROJECT" > /tmp/opensin-gcp-project
+echo "$SA_EMAIL" > /tmp/opensin-sa-email
+
+$GCLOUD secrets list --project="$GCP_PROJECT" --format="value(name)" 2>/dev/null | head -5 || true
+
+log "Phase 2 complete — GCP project and service account ready"

--- a/user-onboarding/scripts/phase3_passwordmanager.sh
+++ b/user-onboarding/scripts/phase3_passwordmanager.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GREEN='\033[0;32m'; RED='\033[0;31m'; BLUE='\033[0;34m'; NC='\033[0m'
+log()  { echo -e "${GREEN}[✓]${NC} $*"; }
+err()  { echo -e "${RED}[✗]${NC} $*"; exit 1; }
+info() { echo -e "${BLUE}[→]${NC} $*"; }
+
+PM_REPO="https://github.com/OpenSIN-AI/OpenSIN-backend.git"
+PM_DIR="$HOME/.config/sin/sin-passwordmanager"
+PM_SRC_RELATIVE="a2a/team-infrastructure/A2A-SIN-Passwordmanager"
+PM_BUILD_DIR="$PM_DIR/build"
+SPM_BIN="$HOME/.local/bin/spm"
+
+mkdir -p "$PM_DIR" "$HOME/.local/bin"
+
+if [ -d "$PM_BUILD_DIR/src" ] && [ -f "$PM_BUILD_DIR/dist/src/cli.js" ]; then
+  log "Passwordmanager already built at $PM_BUILD_DIR"
+else
+  info "Cloning Passwordmanager source (sparse checkout)..."
+  TEMP_CLONE=$(mktemp -d)
+  git clone --depth=1 --filter=blob:none --sparse "$PM_REPO" "$TEMP_CLONE" 2>&1 | tail -1
+  cd "$TEMP_CLONE"
+  git sparse-checkout set "$PM_SRC_RELATIVE" 2>&1
+  
+  cp -r "$TEMP_CLONE/$PM_SRC_RELATIVE" "$PM_BUILD_DIR"
+  rm -rf "$TEMP_CLONE"
+  
+  info "Installing dependencies..."
+  cd "$PM_BUILD_DIR"
+  npm install --production=false 2>&1 | tail -3
+  
+  info "Building TypeScript..."
+  npx tsc 2>&1 || npm run build 2>&1 | tail -3
+  log "Passwordmanager built successfully"
+fi
+
+cat > "$SPM_BIN" << 'SPMEOF'
+#!/usr/bin/env bash
+export SPM_SECRET_BACKEND="${SPM_SECRET_BACKEND:-gcloud}"
+PM_CLI="$HOME/.config/sin/sin-passwordmanager/build/dist/src/cli.js"
+exec node "$PM_CLI" "$@"
+SPMEOF
+chmod +x "$SPM_BIN"
+log "CLI symlink created: $SPM_BIN"
+
+cat > "$PM_DIR/backend.env" << ENVEOF
+SPM_SECRET_BACKEND=gcloud
+SPM_GCLOUD_PROJECT=$(cat /tmp/opensin-gcp-project 2>/dev/null || echo "artificial-biometrics")
+ENVEOF
+
+if [ ! -f "$PM_DIR/catalog.json" ]; then
+  echo '{"secrets":[],"version":1}' > "$PM_DIR/catalog.json"
+  log "Empty catalog created"
+fi
+
+info "Verifying Passwordmanager health..."
+HEALTH=$(SPM_SECRET_BACKEND=gcloud node "$PM_BUILD_DIR/dist/src/cli.js" run-action '{"action":"sin.passwordmanager.health"}' 2>&1)
+if echo "$HEALTH" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['ok']; print(f'  backend: {d[\"backend\"]}'); print(f'  actionsReady: {d[\"actionsReady\"]}')" 2>/dev/null; then
+  log "Passwordmanager health check passed"
+else
+  err "Passwordmanager health check failed:\n$HEALTH"
+fi
+
+log "Phase 3 complete — Passwordmanager ready with gcloud backend"

--- a/user-onboarding/scripts/phase4_chrome_extension.sh
+++ b/user-onboarding/scripts/phase4_chrome_extension.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; BLUE='\033[0;34m'; NC='\033[0m'
+log()  { echo -e "${GREEN}[✓]${NC} $*"; }
+warn() { echo -e "${YELLOW}[!]${NC} $*"; }
+err()  { echo -e "${RED}[✗]${NC} $*"; exit 1; }
+info() { echo -e "${BLUE}[→]${NC} $*"; }
+
+EXT_REPO="https://github.com/OpenSIN-AI/OpenSIN-backend.git"
+EXT_SRC_RELATIVE="services/sin-chrome-extension/extension"
+EXT_DIR="$HOME/.config/sin/opensin-bridge"
+CHROME_APP="/Applications/Google Chrome.app"
+
+if [ -d "$EXT_DIR/background" ] && [ -f "$EXT_DIR/manifest.json" ]; then
+  log "OpenSIN Bridge already exists at $EXT_DIR"
+else
+  info "Cloning OpenSIN Bridge extension source..."
+  TEMP_CLONE=$(mktemp -d)
+  git clone --depth=1 --filter=blob:none --sparse "$EXT_REPO" "$TEMP_CLONE" 2>&1 | tail -1
+  cd "$TEMP_CLONE"
+  git sparse-checkout set "$EXT_SRC_RELATIVE" 2>&1
+  
+  mkdir -p "$EXT_DIR"
+  cp -r "$TEMP_CLONE/$EXT_SRC_RELATIVE/"* "$EXT_DIR/"
+  rm -rf "$TEMP_CLONE"
+  log "Extension files copied to $EXT_DIR"
+fi
+
+EXT_VER=$(python3 -c "import json; print(json.load(open('$EXT_DIR/manifest.json'))['version'])" 2>/dev/null || echo "unknown")
+log "OpenSIN Bridge version: $EXT_VER"
+
+info "To load the extension in Chrome:"
+echo ""
+echo "  Option A (Recommended — Automatic):"
+echo "    1. Open Chrome and go to: chrome://extensions"
+echo "    2. Enable 'Developer mode' (top right toggle)"
+echo "    3. Click 'Load unpacked' and select: $EXT_DIR"
+echo ""
+echo "  Option B (CLI — requires Chrome restart):"
+echo "    Close Chrome, then run:"
+echo "    /Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome \\"
+echo "      --load-extension=\"$EXT_DIR\" \\"
+echo "      --remote-debugging-port=9335"
+echo ""
+
+if pgrep -f "Google Chrome" &>/dev/null; then
+  CDP_PORT=""
+  for port in 9335 9334 9222; do
+    if curl -s "http://localhost:$port/json/version" &>/dev/null; then
+      CDP_PORT=$port
+      break
+    fi
+  done
+  
+  if [ -n "$CDP_PORT" ]; then
+    info "Chrome detected with CDP on port $CDP_PORT"
+    
+    EXTENSIONS_LOADED=$(curl -s "http://localhost:$CDP_PORT/json" 2>/dev/null | python3 -c "
+import sys, json
+tabs = json.load(sys.stdin)
+ext_tabs = [t for t in tabs if 'opensin' in t.get('title','').lower() or 'opensin' in t.get('url','').lower()]
+print(len(ext_tabs))
+" 2>/dev/null || echo "0")
+    
+    if [ "$EXTENSIONS_LOADED" != "0" ]; then
+      log "OpenSIN Bridge appears to be active in Chrome"
+    else
+      warn "OpenSIN Bridge not detected in running Chrome — load it manually via chrome://extensions"
+    fi
+  else
+    warn "Chrome running but no CDP port found — extension status unknown"
+  fi
+else
+  info "Chrome not running — extension will be loaded on next Chrome start"
+fi
+
+log "Phase 4 complete — OpenSIN Bridge extension ready at $EXT_DIR"

--- a/user-onboarding/scripts/phase5_platform_accounts.py
+++ b/user-onboarding/scripts/phase5_platform_accounts.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+Phase 5: Autonomous platform account registration and API key provisioning.
+
+Registers accounts on free-tier AI platforms and stores API keys
+in the SIN-Passwordmanager (Google Cloud Secrets backend).
+
+Supported platforms:
+  - Groq (14,400 free vision requests/day)
+  - NVIDIA NIM (1,000 free API calls/month)
+  - Hugging Face (unlimited free CPU Spaces)
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+PM_CLI = os.path.expanduser("~/.config/sin/sin-passwordmanager/build/dist/src/cli.js")
+SPM_BACKEND = os.environ.get("SPM_SECRET_BACKEND", "gcloud")
+
+GREEN = "\033[0;32m"
+YELLOW = "\033[1;33m"
+BLUE = "\033[0;34m"
+NC = "\033[0m"
+
+
+def log(msg):
+    print(f"{GREEN}[✓]{NC} {msg}")
+
+
+def warn(msg):
+    print(f"{YELLOW}[!]{NC} {msg}")
+
+
+def info(msg):
+    print(f"{BLUE}[→]{NC} {msg}")
+
+
+PLATFORMS = [
+    {
+        "name": "Groq",
+        "key_name": "GROQ_API_KEY",
+        "signup_url": "https://console.groq.com/keys",
+        "description": "Free vision models (llama-3.2-11b-vision, llama-4-scout)",
+        "free_tier": "14,400 requests/day",
+        "tags": ["auth", "groq", "vision", "free-tier"],
+    },
+    {
+        "name": "NVIDIA NIM",
+        "key_name": "NVIDIA_API_KEY",
+        "signup_url": "https://build.nvidia.com/",
+        "description": "Free NIM API (Qwen, Cosmos, Llama models)",
+        "free_tier": "1,000 API calls/month",
+        "tags": ["auth", "nvidia", "nim", "free-tier"],
+    },
+    {
+        "name": "Hugging Face",
+        "key_name": "HUGGINGFACE_TOKEN",
+        "signup_url": "https://huggingface.co/settings/tokens",
+        "description": "Unlimited free CPU Spaces for A2A agent hosting",
+        "free_tier": "Unlimited CPU-basic Spaces",
+        "tags": ["auth", "huggingface", "spaces"],
+    },
+    {
+        "name": "GitHub",
+        "key_name": "GITHUB_TOKEN",
+        "signup_url": "https://github.com/settings/tokens",
+        "description": "GitHub API access for repo management and A2A coordination",
+        "free_tier": "Unlimited public repos",
+        "tags": ["auth", "github"],
+    },
+]
+
+
+def pm_action(action_payload: dict) -> dict | None:
+    try:
+        result = subprocess.run(
+            ["node", PM_CLI, "run-action", json.dumps(action_payload)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env={**os.environ, "SPM_SECRET_BACKEND": SPM_BACKEND},
+        )
+        if result.stdout.strip() and result.stdout.strip() != "undefined":
+            return json.loads(result.stdout.strip())
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+        pass
+    return None
+
+
+def check_key_exists(key_name: str) -> bool:
+    result = pm_action({
+        "action": "sin.passwordmanager.secret.get",
+        "name": key_name,
+        "reveal": False,
+    })
+    return result is not None and "name" in result
+
+
+def store_key(key_name: str, value: str, description: str, tags: list[str]) -> bool:
+    result = pm_action({
+        "action": "sin.passwordmanager.secret.put",
+        "name": key_name,
+        "value": value,
+        "description": description,
+        "tags": tags,
+    })
+    return result is not None and "name" in result
+
+
+def try_autonomous_registration(platform: dict) -> str | None:
+    """
+    Attempt to register on a platform autonomously using browser automation.
+    Returns the API key if successful, None if manual input is needed.
+    
+    This uses the Two-Layer Browser Stack (nodriver + CDP) when available.
+    Falls back to prompting the user for the key.
+    """
+    try:
+        cdp_check = subprocess.run(
+            ["curl", "-s", "http://localhost:9335/json/version"],
+            capture_output=True, text=True, timeout=3
+        )
+        if cdp_check.returncode == 0 and "Chrome" in cdp_check.stdout:
+            info(f"  Chrome CDP available — attempting autonomous {platform['name']} registration...")
+            info(f"  Opening: {platform['signup_url']}")
+            # TODO: Full browser automation for each platform
+            # For now, open the URL and let user complete registration
+            subprocess.run(
+                ["open", platform["signup_url"]],
+                timeout=5
+            )
+            time.sleep(2)
+            return None
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return None
+
+
+def main():
+    info("Phase 5: Platform Account Registration")
+    print()
+
+    if not os.path.exists(PM_CLI):
+        warn(f"Passwordmanager CLI not found at {PM_CLI}")
+        warn("Skipping platform registration — run Phase 3 first")
+        return
+
+    stored_count = 0
+    skipped_count = 0
+    manual_needed = []
+
+    for platform in PLATFORMS:
+        key_name = platform["key_name"]
+        info(f"Checking {platform['name']}...")
+
+        if check_key_exists(key_name):
+            log(f"  {key_name} already exists in Passwordmanager")
+            skipped_count += 1
+            continue
+
+        auto_key = try_autonomous_registration(platform)
+
+        if auto_key:
+            if store_key(auto_key, auto_key, platform["description"], platform["tags"]):
+                log(f"  {key_name} stored autonomously!")
+                stored_count += 1
+                continue
+
+        gh_token = None
+        if key_name == "GITHUB_TOKEN":
+            try:
+                result = subprocess.run(
+                    ["gh", "auth", "token"],
+                    capture_output=True, text=True, timeout=5
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    gh_token = result.stdout.strip()
+                    info(f"  Found GitHub token from gh CLI")
+            except (subprocess.TimeoutExpired, FileNotFoundError):
+                pass
+
+        if gh_token:
+            if store_key(key_name, gh_token, platform["description"], platform["tags"]):
+                log(f"  {key_name} stored from gh CLI")
+                stored_count += 1
+                continue
+
+        manual_needed.append(platform)
+
+    if manual_needed:
+        print()
+        warn(f"{len(manual_needed)} platform(s) need API keys. Register at:")
+        print()
+        for p in manual_needed:
+            print(f"  {p['name']:20s} → {p['signup_url']}")
+            print(f"  {'':20s}   Free tier: {p['free_tier']}")
+            print()
+
+        print("After getting your keys, store them with:")
+        print()
+        for p in manual_needed:
+            print(f"  spm run-action '{json.dumps({\"action\": \"sin.passwordmanager.secret.put\", \"name\": p[\"key_name\"], \"value\": \"YOUR_KEY_HERE\", \"description\": p[\"description\"], \"tags\": p[\"tags\"]})}'")
+        print()
+
+    log(f"Phase 5 complete — {stored_count} keys stored, {skipped_count} already existed, {len(manual_needed)} need manual input")
+
+
+if __name__ == "__main__":
+    main()

--- a/user-onboarding/scripts/phase5_storage_setup.sh
+++ b/user-onboarding/scripts/phase5_storage_setup.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log()  { echo -e "${GREEN}[✓]${NC} $*"; }
+warn() { echo -e "${YELLOW}[!]${NC} $*"; }
+err()  { echo -e "${RED}[✗]${NC} $*"; }
+info() { echo -e "${BLUE}[→]${NC} $*"; }
+
+if [ -f "$HOME/.config/opensin/box-storage-configured" ]; then
+  log "Box.com Storage already configured, skipping..."
+  exit 0
+fi
+
+info "OpenSIN uses Box.com (10 GB free) as primary cloud storage for:"
+echo "  • Public files (logos, images, documents)"
+echo "  • Cache & logs (temporary files)"
+echo ""
+
+warn "IMPORTANT: GitLab Storage is DEAD (account banned). Box.com is the replacement."
+echo ""
+
+echo "Step 1: Create a free Box.com account (10 GB)"
+echo "  1. Open https://www.box.com/signup/ in your browser"
+echo "  2. Register with your email"
+echo "  3. Verify your email"
+echo ""
+read -p "Have you created a Box.com account? (y/n) " -n 1 -r
+echo ""
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  warn "Please create a Box.com account first."
+  echo "  Then re-run: opensin init (or ./scripts/onboard.sh)"
+  exit 1
+fi
+
+log "Box.com account created!"
+
+echo ""
+info "Step 2: Create two folders in your Box.com account:"
+echo "  1. Log into https://app.box.com/"
+echo "  2. Create folder: /OpenSIN-Public (for public files)"
+echo "  3. Create folder: /OpenSIN-Cache (for logs and temp files)"
+echo ""
+read -p "Have you created both folders? (y/n) " -n 1 -r
+echo ""
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  warn "Please create the folders first."
+  exit 1
+fi
+
+log "Folders created!"
+
+echo ""
+info "Step 3: Enable Public Sharing for each folder:"
+echo "  For /OpenSIN-Public:"
+echo "    1. Right-click folder → Share"
+echo "    2. Set to: 'People with the link'"
+echo "    3. Permission: 'Can view'"
+echo "    4. Copy the share link"
+echo ""
+echo "  Repeat for /OpenSIN-Cache"
+echo ""
+read -p "Have you enabled sharing for both folders? (y/n) " -n 1 -r
+echo ""
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  warn "Please enable sharing first."
+  exit 1
+fi
+
+log "Sharing enabled!"
+
+echo ""
+info "Step 4 (Optional): Create Box Developer Token for API access"
+echo "  1. Go to https://app.box.com/developers/console"
+echo "  2. Click 'Create New App' → 'Custom App'"
+echo "  3. Add 'Developer Token' scope"
+echo "  4. Generate token (valid 60 min)"
+echo ""
+read -p "Do you want to create a Developer Token now? (y/n) " -n 1 -r
+echo ""
+
+BOX_DEVELOPER_TOKEN=""
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  read -p "Enter your Developer Token: " BOX_DEVELOPER_TOKEN
+  if [ -n "$BOX_DEVELOPER_TOKEN" ]; then
+    log "Storing Developer Token in passwordmanager..."
+  fi
+fi
+
+mkdir -p "$HOME/.config/opensin"
+touch "$HOME/.config/opensin/box-storage-configured"
+
+log "Box.com Storage setup complete!"
+echo ""
+info "Next steps:"
+echo "  1. Get the folder IDs from Box.com (optional, for API usage):"
+echo "     box folders:children 0"
+echo "  2. Add these to your .env:"
+echo "     BOX_PUBLIC_FOLDER_ID=<id>"
+echo "     BOX_CACHE_FOLDER_ID=<id>"
+echo "  3. Share the folder links with your OpenSIN team"
+echo ""
+echo "  Public folder example: https://app.box.com/s/1st624o9eb5xdistusew5w0erb8offc7"
+echo "  Cache folder example: https://app.box.com/s/9s5htoefw1ux9ajaqj656v9a02h7z7x1"
+echo ""
+echo "⚠️  IMPORTANT: Without proper sharing, the shared links will return 404!"
+echo ""
+
+exit 0

--- a/user-onboarding/scripts/phase6_verification.sh
+++ b/user-onboarding/scripts/phase6_verification.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GREEN='\033[0;32m'; RED='\033[0;31m'; BLUE='\033[0;34m'; NC='\033[0m'
+log()  { echo -e "${GREEN}[✓]${NC} $*"; }
+fail() { echo -e "${RED}[✗]${NC} $*"; FAILURES=$((FAILURES+1)); }
+info() { echo -e "${BLUE}[→]${NC} $*"; }
+
+FAILURES=0
+GCLOUD=$(cat /tmp/opensin-gcloud-path 2>/dev/null || echo "gcloud")
+PM_CLI="$HOME/.config/sin/sin-passwordmanager/build/dist/src/cli.js"
+
+info "Running verification checks..."
+echo ""
+
+info "1. gcloud authentication"
+SA_ACTIVE=$($GCLOUD auth list --format="value(account)" --filter="status:ACTIVE" 2>/dev/null || true)
+if [ -n "$SA_ACTIVE" ]; then
+  log "Active account: $SA_ACTIVE"
+else
+  fail "No active gcloud account"
+fi
+
+info "2. Google Cloud Secrets access"
+if $GCLOUD secrets list --project="$(cat /tmp/opensin-gcp-project 2>/dev/null || $GCLOUD config get-value project 2>/dev/null)" --format="value(name)" 2>/dev/null; then
+  log "Secret Manager access verified"
+else
+  fail "Cannot access Secret Manager"
+fi
+
+info "3. Passwordmanager health"
+if [ -f "$PM_CLI" ]; then
+  HEALTH=$(SPM_SECRET_BACKEND=gcloud node "$PM_CLI" run-action '{"action":"sin.passwordmanager.health"}' 2>/dev/null || echo '{}')
+  if echo "$HEALTH" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d.get('ok')" 2>/dev/null; then
+    log "Passwordmanager healthy (backend: gcloud)"
+  else
+    fail "Passwordmanager health check returned not-ok"
+  fi
+else
+  fail "Passwordmanager CLI not found at $PM_CLI"
+fi
+
+info "4. spm CLI"
+if [ -x "$HOME/.local/bin/spm" ]; then
+  log "spm CLI installed at ~/.local/bin/spm"
+else
+  fail "spm CLI not found at ~/.local/bin/spm"
+fi
+
+info "5. OpenSIN Bridge extension"
+EXT_DIR="$HOME/.config/sin/opensin-bridge"
+if [ -f "$EXT_DIR/manifest.json" ]; then
+  EXT_VER=$(python3 -c "import json; print(json.load(open('$EXT_DIR/manifest.json'))['version'])" 2>/dev/null || echo "?")
+  log "OpenSIN Bridge v$EXT_VER files present"
+else
+  fail "OpenSIN Bridge not found at $EXT_DIR"
+fi
+
+info "6. Service account key"
+KEY_FILE="$HOME/.config/opencode/auth/google/service-account.json"
+if [ -f "$KEY_FILE" ]; then
+  KEY_PERMS=$(stat -f "%Lp" "$KEY_FILE" 2>/dev/null || stat -c "%a" "$KEY_FILE" 2>/dev/null || echo "???")
+  log "SA key exists (permissions: $KEY_PERMS)"
+else
+  fail "SA key file not found at $KEY_FILE"
+fi
+
+echo ""
+echo "═══════════════════════════════════════"
+if [ "$FAILURES" -eq 0 ]; then
+  log "All checks passed! OpenSIN is ready."
+else
+  fail "$FAILURES check(s) failed — review output above"
+fi
+echo "═══════════════════════════════════════"


### PR DESCRIPTION
## Summary

Absorbs the standalone `OpenSIN-AI/OpenSIN-onboarding` repo (39 KB) as `user-onboarding/` inside this repo. Both repos covered the same domain ("set up an OpenSIN environment"), just for different audiences. One repo with clearly-labeled subfolders is better than two overlapping repos.

## Mapping

| Before (to be archived) | After (this PR) |
|---|---|
| `OpenSIN-AI/OpenSIN-onboarding/scripts/` | `user-onboarding/scripts/` |
| `OpenSIN-AI/OpenSIN-onboarding/docs/` | `user-onboarding/docs/` |
| `OpenSIN-AI/OpenSIN-onboarding/config/` | `user-onboarding/config/` |
| `OpenSIN-AI/OpenSIN-onboarding/.well-known/` | `user-onboarding/.well-known/` |

## What is in the PR

- New top-level README that splits into "For developers" and "For end users" paths
- `user-onboarding/` — full content of the onboarding repo, duplicated scaffolding stripped
- Original README preserved verbatim in a `<details>` block

## After merge

1. Archive `OpenSIN-AI/OpenSIN-onboarding` with a redirect README
2. Update `OpenSIN-overview/docs/CANONICAL-REPOS.md` to reflect the merge

Co-authored-by: v0[bot] <v0[bot]@users.noreply.github.com>